### PR TITLE
Run the integration tests on the dodona-python production image

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -1,4 +1,4 @@
-name: Python
+name: Integration test
 
 on:
   push:
@@ -6,25 +6,16 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/dodona-edu/dodona-python:latest
+      options: --user root
 
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-          cache: "pip"
-          cache-dependency-path: |
-            requirements.txt
-            requirements-dev.txt
-      - name: Install dependencies
-        run: ./devel/install_deps.sh
       - name: Install dev dependencies
         run: ./devel/install_dev_deps.sh
-      - name: Running pylama
-        run: ./devel/check.sh
       - name: Run tests
         run: ./devel/run-tests.sh
       - name: Code Coverage

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -11,7 +11,7 @@ jobs:
       options: --user root
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - name: Install dev dependencies

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
-      - name: Install dev dependencies
-        run: ./devel/install_dev_deps.sh
+      - name: Install test dependencies
+        run: ./devel/install_test_deps.sh
       - name: Run tests
         run: ./devel/run-tests.sh
       - name: Code Coverage

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Lint
+
+on:
+  push:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+      - name: Install dependencies
+        run: ./devel/install_deps.sh
+      - name: Install dev dependencies
+        run: ./devel/install_dev_deps.sh
+      - name: Running pylama
+        run: ./devel/check.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,7 @@ jobs:
           cache-dependency-path: |
             requirements.txt
             requirements-dev.txt
+            requirements-test.txt
       - name: Install dependencies
         run: ./devel/install_deps.sh
       - name: Install dev dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - name: Setup Python

--- a/devel/install_test_deps.sh
+++ b/devel/install_test_deps.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+ROOT="$(dirname "$(dirname "$0")")"
+
+pip3 install -r "$ROOT/requirements-test.txt"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,6 @@
-setuptools==68.2.2
+-r requirements-test.txt
 
-pytest==7.2.0
-pytest-cov==4.0.0
-pytest-xdist==3.2.0
-pytest-subtests==0.10.0
+setuptools==68.2.2
 
 black==24.3.0
 isort==5.12.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+pytest==7.2.0
+pytest-cov==4.0.0
+pytest-xdist==3.2.0
+pytest-subtests==0.10.0


### PR DESCRIPTION
Runs the turtle judge's test suite inside the production image (`ghcr.io/dodona-edu/dodona-python:latest`, the image turtle deploys to) instead of a hand-pinned `setup-python` 3.10, so the judge is tested against the environment it actually runs on.

## What changed

The single `python.yml` job is split into two workflows:

- **`lint.yml`** — keeps running pylama on the pinned dev toolchain (`setup-python` + `requirements-dev.txt`). Linting is a code-quality check and is sensitive to the exact pylint version, so it stays on the pinned tools rather than the image's pylint.
- **`integration_test.yml`** — runs `run-tests.sh` (and coverage) inside `dodona-python:latest`. The image already ships turtle's exact runtime deps (svg-turtle 0.4.2, Pillow 10.0.1, cairosvg 2.7.1, numpy 1.26.0), so only the dev/test deps are layered on top.

This moves the functional tests from Python 3.10 to the image's Python 3.12.9, which is what production runs. First slice of dodona-edu/dodona#8329 (Direction A for turtle).

## Manual testing

Ran inside the image locally:

- `run-tests.sh`: 7 passed on Python 3.12.9.
- `pylama` stays on `setup-python` where it's already green. (The image's pylint 3.0.1 flags a style nit on the new input-reading code that the pinned linter doesn't, which is exactly why lint shouldn't run on the image's pylint.)

CI on this branch confirms both jobs.
