### PR TITLE
Harden the devel scripts and drop the dead submodule config

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -12,8 +12,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: true
       - name: Install test dependencies
         run: ./devel/install_test_deps.sh
       - name: Run tests

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,8 +9,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: true
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/devel/check.sh
+++ b/devel/check.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
+set -euo pipefail
 
 ROOT="$(dirname "$(dirname "$0")")"
 
-cd "$ROOT" || exit
+cd "$ROOT"
 
 pytest \
     --pylama \

--- a/devel/format.sh
+++ b/devel/format.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
+set -euo pipefail
 
 ROOT="$(dirname "$(dirname "$0")")"
-cd "$ROOT" || exit
+
+cd "$ROOT"
 
 isort ./*.py
 isort ./**/*.py

--- a/devel/install_deps.sh
+++ b/devel/install_deps.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 ROOT="$(dirname "$(dirname "$0")")"
 

--- a/devel/install_dev_deps.sh
+++ b/devel/install_dev_deps.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 ROOT="$(dirname "$(dirname "$0")")"
 

--- a/devel/install_test_deps.sh
+++ b/devel/install_test_deps.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 ROOT="$(dirname "$(dirname "$0")")"
 

--- a/devel/learn-e2e.sh
+++ b/devel/learn-e2e.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
+set -euo pipefail
 
 ROOT="$(dirname "$(dirname "$0")")"
 
-cd "$ROOT" || exit
+cd "$ROOT"
 
 # On macOS, ensure Homebrew libraries (e.g. cairo) are discoverable
 if [ "$(uname)" = "Darwin" ] && command -v brew > /dev/null 2>&1; then
     export DYLD_FALLBACK_LIBRARY_PATH="$(brew --prefix)/lib:${DYLD_FALLBACK_LIBRARY_PATH:-}"
 fi
-
-git submodule update --init
 
 LEARN_OUTPUT="YES" pytest tests/test_e2e.py -v -s

--- a/devel/run-tests.sh
+++ b/devel/run-tests.sh
@@ -1,15 +1,14 @@
 #!/bin/bash
+set -euo pipefail
 
 ROOT="$(dirname "$(dirname "$0")")"
 
-cd "$ROOT" || exit
+cd "$ROOT"
 
 # On macOS, ensure Homebrew libraries (e.g. cairo) are discoverable
 if [ "$(uname)" = "Darwin" ] && command -v brew > /dev/null 2>&1; then
     export DYLD_FALLBACK_LIBRARY_PATH="$(brew --prefix)/lib:${DYLD_FALLBACK_LIBRARY_PATH:-}"
 fi
-
-git submodule update --init
 
 pytest -n auto \
     --cov \


### PR DESCRIPTION
This PR hardens the devel scripts (to use `set -euo pipefail` and doesn't exit when `cd` fails.

<details>

Two small things in the `devel/` scripts, to match judge-sql and judge-html.

**`set -euo pipefail` everywhere.** The scripts had none of it, and `cd "$ROOT" || exit` instead. The one place it actually bites today is `format.sh`: if `isort` fails it still runs `black` over the same files and reports success. The rest is consistency, so the next script added here inherits the right defaults instead of the old ones.

**Dropped the submodule config.** There is no `.gitmodules` in this repo, so `git submodule update --init` in `run-tests.sh` and `learn-e2e.sh`, and `submodules: true` on both workflow checkouts, were no-ops. The e2e fixtures under `tests/e2e_repos/` are 23 ordinary tracked files. judge-sql really does have a submodule and needs that config, which is probably where it was copied from.

Stacked on #93, which has to land first or the e2e suite is red for an unrelated reason.

<details>
<summary>bash 3.2 check</summary>

`set -u` combined with an empty `"$@"` errors on bash before 4.4, and macOS still ships 3.2. `run-tests.sh` and `check.sh` both forward `"$@"`, so I checked rather than assumed:

```sh
$ /bin/bash --version | head -1
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)
$ /bin/bash -c 'set -euo pipefail; echo "argcount=$#" "$@"'
argcount=0
```

Fine, both at top level and inside a function. The macOS Homebrew/cairo block in `run-tests.sh` and `learn-e2e.sh` already guarded its expansion with `:-`, so that needed nothing.

</details>
</details>

## Testing

```sh
docker run --rm --platform linux/amd64 -v "$PWD:/w" -w /w --user root \
  ghcr.io/dodona-edu/dodona-python:latest \
  sh -c "./devel/install_test_deps.sh && ./devel/run-tests.sh"
```

`7 passed`, exit 0.
