### PR TITLE
Point the pins at what the production image actually ships

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           cache: "pip"
           cache-dependency-path: |
             requirements.txt

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,3 @@
-python 3.10
+# Must match the base image pinned in dodona-edu/docker-images/dodona-python.dockerfile,
+# so local development runs exactly the interpreter production runs. Bump the two together.
+python 3.12.9

--- a/judge/runtime.py
+++ b/judge/runtime.py
@@ -59,8 +59,8 @@ def generate_png_image(svg_bytes: bytes, width: int, height: int) -> Image.Image
 def diff_images(submission: Image.Image, solution: Image.Image) -> tuple[int, int, int]:
     """Generate difference between two images, and return the number differing pixels."""
     # int(): np.count_nonzero returns an np.int64, which json.dumps refuses. These values only
-    # ever reach the feedback as interpolated text today, so nothing breaks, but the annotation
-    # below says int and a caller that puts one straight into a command would fail at runtime.
+    # ever reach the feedback as interpolated text today, so nothing breaks, but the signature
+    # above promises int and a caller that puts one straight into a command would fail at runtime.
     wrong_pixels = int(np.count_nonzero(np.array(ImageChops.difference(submission, solution)).any(axis=-1)))
     total_non_transparent_pixels = int(
         np.count_nonzero(np.array(submission).any(axis=-1) | np.array(solution).any(axis=-1))

--- a/judge/runtime.py
+++ b/judge/runtime.py
@@ -58,9 +58,14 @@ def generate_png_image(svg_bytes: bytes, width: int, height: int) -> Image.Image
 
 def diff_images(submission: Image.Image, solution: Image.Image) -> tuple[int, int, int]:
     """Generate difference between two images, and return the number differing pixels."""
-    wrong_pixels = np.count_nonzero(np.array(ImageChops.difference(submission, solution)).any(axis=-1))
-    total_non_transparent_pixels = np.count_nonzero(np.array(submission).any(axis=-1) | np.array(solution).any(axis=-1))
+    # int(): np.count_nonzero returns an np.int64, which json.dumps refuses. These values only
+    # ever reach the feedback as interpolated text today, so nothing breaks, but the annotation
+    # below says int and a caller that puts one straight into a command would fail at runtime.
+    wrong_pixels = int(np.count_nonzero(np.array(ImageChops.difference(submission, solution)).any(axis=-1)))
+    total_non_transparent_pixels = int(
+        np.count_nonzero(np.array(submission).any(axis=-1) | np.array(solution).any(axis=-1))
+    )
     correct_non_transparent_pixels = total_non_transparent_pixels - wrong_pixels
-    expected_non_transparent_pixels = np.count_nonzero(np.array(solution).any(axis=-1))
+    expected_non_transparent_pixels = int(np.count_nonzero(np.array(solution).any(axis=-1)))
 
     return correct_non_transparent_pixels, total_non_transparent_pixels, expected_non_transparent_pixels

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-svg-turtle==0.4.2
-Pillow==10.0.1
-cairosvg==2.7.1
-numpy==1.26.0
+# These mirror dodona-edu/docker-images/dodona-python.dockerfile: the judge runs with
+# whatever that image ships, so a pin that differs from it is a lie about production.
+svg-turtle==1.1.0
+Pillow==12.2.0
+cairosvg==2.9.0
+numpy==2.4.6


### PR DESCRIPTION
This PR updates the dependencies and Python version to what's actually being used in the image.

<details>

`requirements.txt` and `.tool-versions` described an environment that hasn't existed for a while:

| | pinned here | `dodona-python` ships |
|---|---|---|
| python | 3.10 | 3.12.9 |
| svg-turtle | 0.4.2 | 1.1.0 |
| Pillow | 10.0.1 | 12.2.0 |
| cairosvg | 2.7.1 | 2.9.0 |
| numpy | 1.26.0 | 2.4.6 |

Nothing catches this. The integration test installs only `requirements-test.txt` and then runs against the image's own site-packages, so `requirements.txt` is never exercised anywhere. It's read by people setting up locally, and it was sending them to a four-year-old svg-turtle. The `px` breakage in #93 is what this drift looks like when it finally surfaces.

Same comment judge-html carries on both files, since the reasoning is the same: the judge runs with whatever the image ships, so a pin that differs from it is a lie about production.

The lint job moves from python 3.10 to 3.12 with it, so it stops type- and syntax-checking against a different interpreter from the one production runs.

## Two commits, on purpose

The second one is a real (if currently harmless) type fix that the numpy bump uncovered, and it reads better on its own than buried in the pins diff.

Moving to numpy 2.4.6 makes the lint job go red: numpy's stubs got more accurate in 2.x, and mypy now sees that `np.count_nonzero` returns an `np.int64` while `diff_images` is annotated `tuple[int, int, int]`.

That's not a stub bug, it's true at runtime:

```
>>> type(np.count_nonzero(np.array([[1,0],[0,1]])))
<class 'numpy.int64'>
>>> json.dumps({'v': np.count_nonzero(np.array([[1,0],[0,1]]))})
TypeError: Object of type int64 is not JSON serializable
```

Nothing breaks today, because all three counts reach the feedback through string interpolation into the translated `FOREGROUND_PIXELS_CORRECT` text, so `json.dumps` never sees one. It would break the moment someone passed one straight into a Dodona command, and the error would point at the JSON layer rather than here. So they're wrapped in `int()` and the annotation is true again.

I'd normally split that out into its own PR ahead of this one, the way judge-sql#219 sat ahead of its rule change, but it has to land together with the bump to keep the lint green, and it can't go earlier in the stack without a force push.


</details>

## Testing

The pins now match the image exactly, which is checkable directly. Installing them inside the image is a complete no-op, every line "already satisfied", no downloads:

```sh
docker run --rm --platform linux/amd64 -v "$PWD:/w" -w /w --user root \
  ghcr.io/dodona-edu/dodona-python:latest \
  sh -c "pip3 install -r requirements.txt"
```

Lint reproduced the way CI runs it, on python 3.12 with the new pins, green end to end (`7 passed`, `judge/runtime.py` included):

```sh
docker run --rm --platform linux/amd64 -v "$PWD:/w" -w /w python:3.12.9-bookworm \
  sh -c "./devel/install_deps.sh && ./devel/install_dev_deps.sh && ./devel/check.sh"
```

Suite still `7 passed` in the image, and `mise current python` resolves `3.12.9` from the commented `.tool-versions` (the comment doesn't confuse it).

<details>
<summary>The dependabot side of this</summary>

There is an open dependabot PR here (#79) wanting Pillow 12.3.0, one version ahead of the image's 12.2.0. Under this policy that one gets closed rather than merged: the pin follows the image, and it moves when `docker-images` moves, not before. judge-html sits in the same position today (#264 wants beautifulsoup4 4.15.0 over its pinned 4.13.3), so this is consistent with there rather than new.

Worth a follow-up: `requirements-dev.txt` pins `setuptools==68.2.2` where the image has 82.0.1. I left it alone since it's dev tooling rather than the judge's runtime, and it belongs with the dependabot refresh instead.

</details>

Stacked on #94.
