### PR TITLE
Refresh the GitHub Actions and move the coverage upload out of the image

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -11,12 +11,28 @@ jobs:
       options: --user root
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install test dependencies
         run: ./devel/install_test_deps.sh
       - name: Run tests
         run: ./devel/run-tests.sh
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage
+          path: coverage.xml
+
+  # codecov-action needs curl and gpg. They happen to be in this image, but we'd
+  # rather not depend on the environment the test is meant to exercise shipping them.
+  coverage:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          name: coverage
       - name: Code Coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: "pip"


### PR DESCRIPTION
This PR updates the github actions and moves the coverage upload out of the image.

<details>
Brings the pinned actions up to what judge-sql and judge-html run, and moves the codecov upload out of the production container.

| | was | now |
|---|---|---|
| `actions/checkout` | v6 | v7 |
| `actions/setup-python` | v4 | v7 |
| `codecov/codecov-action` | v5 | v7 |
| `actions/upload-artifact` | | v7 |
| `actions/download-artifact` | | v8 |

**The coverage split.** `codecov-action` needs curl and gpg. `dodona-python` happens to ship both, so this works today, but the whole point of the container job is to run in the environment production runs in. Depending on that environment for our own tooling is how it quietly stops being representative. So the test job uploads `coverage.xml` as an artifact and a plain ubuntu job sends it on, same as judge-sql and judge-html.

The comment in the workflow says "happen to be in this image" rather than judge-html's "doesn't ship them", since here it's a choice rather than a hard requirement.

</details>

## Testing

Both files parse, and each action major exists (checked against the latest release of each, rather than assuming judge-html's pins are current):

```
actions/checkout          v7.0.1
actions/setup-python      v7.0.0
actions/upload-artifact   v7.0.1
actions/download-artifact v8.0.1
codecov/codecov-action    v7.0.0
```

The real check is CI on this branch: `on: push` fires both workflows, so the run on this branch exercises the new job graph, including whether the artifact hand-off between `test` and `coverage` works.

Stacked on #95.
