### PR TITLE
Stop codecov from commenting on every pull request

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,3 @@
+# No comment on the pull request: the numbers still show up as checks, and a bot
+# comment on every PR is just noise.
+comment: false


### PR DESCRIPTION
This PR stops codecov from commenting on every pull request.

Adds a `codecov.yaml` with `comment: false`, the same call as judge-html#263.

<details>
There was no codecov config here at all, so the bot comments on every PR by default. The numbers already show up as checks, so the comment is duplicate noise on top.

Kept to just that one key. judge-html's file also carries `round`, `precision` and an `ignore` for tests, but those predate the decision and aren't part of it, and the `ignore` would be redundant here anyway since `.coveragerc` already omits `tests/*`.
</details>

## Testing

Not really testable before it's on `main`: codecov reads the config from the default branch, so the effect only shows on the first PR after this lands. Worth a glance at the next PR's comments to confirm it took.

Stacked on #96.
