### PR TITLE
Replace black, isort and pylama with ruff

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,0 @@
-[run]
-omit =
-    .github/*
-    htmlcov/*
-    */site-packages/*
-    tests/*
-    venv/*
-source = .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,5 +22,5 @@ jobs:
         run: ./devel/install_deps.sh
       - name: Install dev dependencies
         run: ./devel/install_dev_deps.sh
-      - name: Running pylama
+      - name: Run the linters
         run: ./devel/check.sh

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,10 @@
 {
     "editor.formatOnSave": true,
     "python.analysis.typeCheckingMode": "basic",
-    "python.formatting.provider": "black",
-    "python.formatting.blackArgs": [
-        "--line-length=120"
-    ]
+    "[python]": {
+        "editor.defaultFormatter": "charliermarsh.ruff",
+        "editor.codeActionsOnSave": {
+            "source.organizeImports.ruff": true
+        }
+    }
 }

--- a/devel/check.sh
+++ b/devel/check.sh
@@ -5,7 +5,6 @@ ROOT="$(dirname "$(dirname "$0")")"
 
 cd "$ROOT"
 
-pytest \
-    --pylama \
-    --ignore="tests" \
-    "$@"
+ruff check .
+ruff format --check .
+mypy turtle_judge.py judge/

--- a/devel/format.sh
+++ b/devel/format.sh
@@ -5,7 +5,5 @@ ROOT="$(dirname "$(dirname "$0")")"
 
 cd "$ROOT"
 
-isort ./*.py
-isort ./**/*.py
-black ./*.py --line-length=120
-black ./**/*.py --line-length=120
+ruff check --fix .
+ruff format .

--- a/judge/dodona_config.py
+++ b/judge/dodona_config.py
@@ -6,7 +6,9 @@ from types import SimpleNamespace
 from typing import Any, Union
 
 
-class DodonaConfig(SimpleNamespace):  # noqa: R0902
+# PLW1641: __eq__ without __hash__. SimpleNamespace already defines __eq__ and is already
+# unhashable, so adding __hash__ here would make DodonaConfig hashable where its base is not.
+class DodonaConfig(SimpleNamespace):  # noqa: PLW1641
     """a class for containing all Dodona Judge configuration.
 
     Attributes:

--- a/judge/runtime.py
+++ b/judge/runtime.py
@@ -5,8 +5,8 @@ import os
 from io import BytesIO
 
 import numpy as np
-from cairosvg import svg2png  # noqa
-from PIL import Image, ImageChops  # noqa
+from cairosvg import svg2png
+from PIL import Image, ImageChops
 
 from .runtime_patch import InOutPatch, RuntimePatch, TimePatch, TurtlePatch
 
@@ -20,7 +20,9 @@ def run_file(file_path: str, width: int, height: int, stdin_data: str = ""):
     with io.open_code(decoded_path) as code_file:
         code = compile(code_file.read(), script_name, "exec")
 
-    run_code = __builtins__["exec"]  # noqa
+    # In an imported module __builtins__ is the builtins dict, not the module, so this is fine
+    # at runtime. mypy only knows the __main__ case, where it is the module.
+    run_code = __builtins__["exec"]  # type: ignore[index]
 
     with (
         TurtlePatch(width, height) as turtle,

--- a/judge/runtime_patch.py
+++ b/judge/runtime_patch.py
@@ -6,8 +6,8 @@ from io import StringIO
 from types import TracebackType
 from typing import Any, Literal
 
-from svg_turtle import SvgTurtle  # noqa
-from svg_turtle.canvas import Canvas  # noqa
+from svg_turtle import SvgTurtle
+from svg_turtle.canvas import Canvas
 
 
 class Patch(ABC):

--- a/judge/translator.py
+++ b/judge/translator.py
@@ -129,8 +129,7 @@ class Translator:
             Text.SUBMISSION_EXECUTION_ERROR: "Error executing submission script:\n    {error}",
             Text.SOLUTION_TITLE: "Solution:",
             Text.SUBMISSION_TITLE: "Submission:",
-            Text.FOREGROUND_PIXELS_CORRECT: "{correct_pixels}/{total_pixels} "
-            "({fraction:.1%}) visible pixels correct",
+            Text.FOREGROUND_PIXELS_CORRECT: "{correct_pixels}/{total_pixels} ({fraction:.1%}) visible pixels correct",
         },
         Language.NL: {
             Text.COMPARING_IMAGES: "Afbeeldingen vergelijken",
@@ -139,7 +138,6 @@ class Translator:
             Text.SUBMISSION_EXECUTION_ERROR: "Error bij het uitvoeren van het ingediende script:\n    {error}",
             Text.SOLUTION_TITLE: "Oplossing:",
             Text.SUBMISSION_TITLE: "Indiening:",
-            Text.FOREGROUND_PIXELS_CORRECT: "{correct_pixels}/{total_pixels} "
-            "({fraction:.1%}) zichtbare pixels correct",
+            Text.FOREGROUND_PIXELS_CORRECT: "{correct_pixels}/{total_pixels} ({fraction:.1%}) zichtbare pixels correct",
         },
     }

--- a/pylama.ini
+++ b/pylama.ini
@@ -1,8 +1,0 @@
-[pylama]
-format = pylint
-linters = eradicate,mccabe,mypy,pycodestyle,pydocstyle,pyflakes,pylint,isort
-skip = tests/*
-max_line_length = 120
-
-[pylama:pydocstyle]
-convention = google

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,36 @@
-[tool.isort]
-profile = "black"
+[tool.coverage.run]
+omit = [
+    ".github/*",
+    "htmlcov/*",
+    "*/site-packages/*",
+    "tests/*",
+    "venv/*",
+]
+source = ["."]
 
-[tool.black]
+[tool.ruff]
 line-length = 120
+extend-exclude = ["tests/e2e_repos"]
+# Keep in step with .tool-versions; ruff defaults to py310 and can't infer it without a [project] table.
+target-version = "py312"
+
+[tool.ruff.lint]
+# The pylama.ini line-up this replaces: pycodestyle (E, W), pyflakes (F), pydocstyle (D),
+# mccabe (C90), isort (I), eradicate (ERA), pylint (PL). RUF100 keeps the noqa comments honest.
+select = ["E", "W", "F", "D", "C90", "I", "ERA", "PL", "RUF100"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.per-file-ignores]
+# Ignores rather than an exclude, so `ruff format` still applies to the tests.
+# pylama skipped them outright, so this is no less coverage than before.
+"tests/*" = ["ALL"]
+
+[tool.mypy]
+# pylama ran mypy with --ignore-missing-imports folded in, which is why the blanket `# noqa`
+# comments on these imports used to be enough. Standalone mypy needs it said out loud, and
+# naming the modules beats a global switch: a new untyped dependency should be a decision.
+[[tool.mypy.overrides]]
+module = ["svg_turtle.*", "cairosvg"]
+ignore_missing_imports = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,4 @@
 -r requirements-test.txt
 
-setuptools==68.2.2
-
-black==24.3.0
-isort==5.12.0
-
-pylama[all]==8.4.1
-pydocstyle==6.1.1
+ruff==0.16.3
+mypy==2.3.1

--- a/turtle_judge.py
+++ b/turtle_judge.py
@@ -46,9 +46,12 @@ with Judgement():
 
     if not os.path.exists(config.solution_file):
         with Tab(config.translator.translate(Translator.Text.RENDERING)):
-            with Context(), TestCase(
-                format=MessageFormat.PYTHON,
-                description="",
+            with (
+                Context(),
+                TestCase(
+                    format=MessageFormat.PYTHON,
+                    description="",
+                ),
             ):
                 try:
                     svg_submission = generate_svg_byte_stream(
@@ -79,9 +82,12 @@ with Judgement():
                     test.status = config.translator.error_status(ErrorType.CORRECT)
     else:
         with Tab(config.translator.translate(Translator.Text.COMPARING_IMAGES)):
-            with Context(), TestCase(
-                format=MessageFormat.PYTHON,
-                description="",
+            with (
+                Context(),
+                TestCase(
+                    format=MessageFormat.PYTHON,
+                    description="",
+                ),
             ):
                 try:
                     svg_submission = generate_svg_byte_stream(


### PR DESCRIPTION
This PR replaces black, isort and pylama with ruff. Still on a set list of opted in rules, to be changed later to ALL with exclusions when we get there.

<details> 
Swaps black, isort and pylama for ruff, the same move as judge-sql#206. mypy stays for now and gets replaced by `ty` later in the stack.

The rule set is chosen to match what `pylama.ini` actually enforced rather than to be a fresh start, so this is as close to a like-for-like swap as it can be:

| pylama linter | ruff |
|---|---|
| pycodestyle | `E`, `W` |
| pyflakes | `F` |
| pydocstyle | `D` (google convention) |
| mccabe | `C90` |
| isort | `I` |
| eradicate | `ERA` |
| pylint | `PL` |

Plus `RUF100`, so a `noqa` that stops doing anything gets flagged instead of lingering. Widening past this is a separate PR.

**Why bother.** Less about ruff being fast, more that pylama 8.4.1 is the final release of an unmaintained project and leaves its bundled linters unpinned, so what CI enforces can change under us without a commit. judge-sql hit exactly that and had to pin `setuptools<80.9.0` and `pydocstyle<6.2` to keep its lint job alive. The pins here (`pydocstyle==6.1.1`, `setuptools==68.2.2`) are the same story, and they go away with pylama.

`.coveragerc` and `pylama.ini` fold into `pyproject.toml`, so there's one config file like judge-sql and judge-html.

## Two things the swap surfaced

**The `# noqa` comments were for mypy, not for the linters.** `RUF100` flagged five as unused, which is true for ruff, and removing them turned the lint red: they were suppressing pylama's *embedded* mypy. Standalone mypy is stricter, so that's now said out loud instead of by accident, and narrowly:

- `svg_turtle` and `cairosvg` ship no stubs and no `py.typed`, declared in `[tool.mypy.overrides]`. Naming the modules rather than flipping a global `ignore_missing_imports`, so a new untyped dependency stays a decision.
- `__builtins__["exec"]` gets `# type: ignore[index]` with the reason: in an imported module `__builtins__` is the builtins dict, so it's fine at runtime, and mypy only models the `__main__` case where it's the module.

**`DodonaConfig` overrides `__eq__` without `__hash__` (PLW1641).** Suppressed rather than fixed, since `SimpleNamespace` already defines `__eq__` and is therefore already unhashable. Adding `__hash__` would make the subclass hashable where its base isn't, which is a behaviour change and not the one the rule is asking for. The reasoning sits next to the class. It also replaces a stale `# noqa: R0902`, a pylint code that meant nothing anymore.

</details>

## Testing

Lint reproduced the way CI runs it:

```sh
docker run --rm --platform linux/amd64 -v "$PWD:/w" -w /w python:3.12.9-bookworm \
  sh -c "./devel/install_deps.sh && ./devel/install_dev_deps.sh && ./devel/check.sh"
```

```
All checks passed!
14 files already formatted
Success: no issues found in 7 source files
```

Suite still `7 passed` in the production image, and the e2e golden are untouched, so `ruff format` reflowing `turtle_judge.py` didn't move the rendered feedback. Coverage survives the move out of `.coveragerc`: same 7 source files in `coverage.xml`, `tests/` still omitted.

Stacked on #97.
