### PR TITLE
Fix the __exit__ annotations flagged by ruff PYI036

### DIFF
--- a/judge/dodona_command.py
+++ b/judge/dodona_command.py
@@ -256,9 +256,9 @@ class DodonaCommand(ABC):
 
     def __exit__(
         self,
-        exc_type: type[BaseException],
-        exc_val: BaseException,
-        exc_tb: TracebackType,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
     ) -> bool:
         """Print the close message when exiting the 'with' block & handle enclosed exceptions.
 

--- a/judge/runtime_patch.py
+++ b/judge/runtime_patch.py
@@ -31,9 +31,9 @@ class Patch(ABC):
 
     def __exit__(
         self,
-        exc_type: type[BaseException],
-        exc_val: BaseException,
-        exc_tb: TracebackType,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
     ) -> Literal[False]:
         """Drop generator when leaving the 'with' block. This invokes the finally block in the generator.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,9 @@ target-version = "py312"
 [tool.ruff.lint]
 # The pylama.ini line-up this replaces: pycodestyle (E, W), pyflakes (F), pydocstyle (D),
 # mccabe (C90), isort (I), eradicate (ERA), pylint (PL). RUF100 keeps the noqa comments honest.
-select = ["E", "W", "F", "D", "C90", "I", "ERA", "PL", "RUF100"]
+# PYI036 guards the __exit__ signatures: it catches the missing `| None` that makes every
+# Dodona 'with' block fail a type checker's context manager check.
+select = ["E", "W", "F", "D", "C90", "I", "ERA", "PL", "RUF100", "PYI036"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"


### PR DESCRIPTION
This PR fixes the __exit__annotations to get optional arguments.

<details>

Both context managers here annotate `__exit__` without the `| None` arm:

```python
def __exit__(
    self,
    exc_type: type[BaseException],
    exc_val: BaseException,
    exc_tb: TracebackType,
) -> bool:
```

The three arguments are `None` on the normal, no-exception path, so as written a type checker refuses every `with Judgement(...)`, `with Tab(...)`, `with Message(...)` and `with TurtlePatch(...)` in the judge. Same fix as judge-sql#219 and judge-html#260, which both hit it in their copy of `dodona_command.py`.

Doing it now rather than folding it into the `ty` PR, because it's most of what `ty` would report and it reads better on its own. On this tree `ty` finds 31 diagnostics; widening these two signatures takes it to 17. Fourteen findings from two annotations, since every failing `with` block was downstream of the same two roots. judge-html saw the same cascade.

`PYI036` joins the ruff select list to hold it. It and `ty`'s `invalid-context-manager` catch the same regression from opposite ends, and ruff is the faster and clearer of the two, so trimming the `| None` back off fails sooner.

Annotations only, no behaviour change.

</details>

## Testing

```sh
docker run --rm --platform linux/amd64 -v "$PWD:/w" -w /w python:3.12.9-bookworm \
  sh -c "pip install ty==0.0.72 && ./devel/install_deps.sh && \
         ty check --python \$(command -v python3) turtle_judge.py judge/"
```

`Found 31 diagnostics` on the parent commit, `Found 17 diagnostics` here. `./devel/check.sh` green, suite still `7 passed` in the production image.

Stacked on #98.
