### PR TITLE
Swap mypy for ty

### DIFF
--- a/devel/check.sh
+++ b/devel/check.sh
@@ -7,4 +7,6 @@ cd "$ROOT"
 
 ruff check .
 ruff format --check .
-mypy turtle_judge.py judge/
+# --python is required: CI has no .venv and no activated venv, so without
+# it ty resolves based on what's available, which varies by machine.
+ty check --python "$(command -v python3)" turtle_judge.py judge/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,19 +35,14 @@ convention = "google"
 # pylama skipped them outright, so this is no less coverage than before.
 "tests/*" = ["ALL"]
 
-[tool.mypy]
-# pylama ran mypy with --ignore-missing-imports folded in, which is why the blanket `# noqa`
-# comments on these imports used to be enough. Standalone mypy needs it said out loud, and
-# naming the modules beats a global switch: a new untyped dependency should be a decision.
-[[tool.mypy.overrides]]
-module = ["svg_turtle.*", "cairosvg"]
-ignore_missing_imports = true
+[[tool.ty.overrides]]
+include = ["judge/runtime_patch.py"]
+# This module swaps attributes on live stdlib modules (turtle, time, io, sys.stdin) and hands the
+# submission a fake. A type checker models a module as a static namespace, so every patch line
+# reads as an error. All 17 of ty's diagnostics on this tree are in here, and they are the point
+# of the file rather than bugs in it. Everything else is checked normally.
 
-[[tool.mypy.overrides]]
-module = "judge.runtime_patch"
-# This module's whole job is to swap attributes on live stdlib modules (turtle, time, io, sys.stdin)
-# and hand the submission a fake. mypy models a module as a static namespace, so every patch line
-# reads as an error. Adding return annotations made mypy start checking these bodies, which it
-# skipped while they were unannotated, so the findings are pre-existing rather than new.
-# Narrowed to the three codes dynamic patching produces instead of switching the file off.
-disable_error_code = ["assignment", "attr-defined", "index"]
+[tool.ty.overrides.rules]
+unresolved-attribute = "ignore"
+invalid-assignment = "ignore"
+invalid-argument-type = "ignore"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 -r requirements-test.txt
 
 ruff==0.16.3
-mypy==2.3.1
+ty==0.0.72


### PR DESCRIPTION
This PR swapw mypy for ty.

<details>
Swaps mypy for `ty`, same as judge-sql#220 and judge-html#260, so all three judges type check with the same tool.

`ty` finds 17 diagnostics on this tree and every one is in `judge/runtime_patch.py`, which is the same module mypy needed scoping out of in #100, for the same reason: it swaps attributes on live stdlib modules (`turtle`, `time`, `io`, `sys.stdin`) and hands the submission a fake. A type checker models a module as a static namespace, so each patch line reads as an error. They're what the file is for, not bugs in it.

So the `[[tool.mypy.overrides]]` block becomes a `[[tool.ty.overrides]]` one, turning off `unresolved-attribute`, `invalid-assignment` and `invalid-argument-type` for that one file. Rules rather than the file, and no blanket `# ty: ignore` anywhere.

The lint job already runs `install_deps.sh`, so `ty` can resolve `svg_turtle` and friends. Worth keeping: without the runtime deps ty reports `unresolved-import` and, worse, types everything they return as `Unknown`, so it quietly stops checking. judge-html had to add that step; here it was already there from before.

`--python "$(command -v python3)"` for the same reason judge-sql gives: CI has no venv, so without it ty resolves against whatever happens to be around, which varies by machine.

</details>

## Testing

```sh
docker run --rm --platform linux/amd64 -v "$PWD:/w" -w /w python:3.12.9-bookworm \
  sh -c "./devel/install_deps.sh && ./devel/install_dev_deps.sh && ./devel/check.sh"
```

Green end to end (ruff check, ruff format, ty). Suite still `7 passed` in the production image.

I didn't want to take "no diagnostics" as proof the override was scoped right, so I checked it both ways with a deliberate `def _canary() -> int: return "not an int"`:

- dropped in `judge/runtime.py` (not covered by the override), ty reports it. So the override didn't quietly switch checking off everywhere.
- dropped in `judge/runtime_patch.py` (covered by the override), ty still reports it. So the file is genuinely still type checked and only those three rules are off.

Stacked on #100.
