### PR TITLE
Refresh the dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,5 @@
 version: 2
 updates:
-  # requirements.txt mirrors dodona-edu/docker-images/dodona-python.dockerfile on purpose, so a
-  # bump to svg-turtle, Pillow, cairosvg or numpy that the image hasn't taken yet gets closed
-  # rather than merged. Those four move when the image moves.
   - package-ecosystem: pip
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,32 @@
 version: 2
 updates:
+  # requirements.txt mirrors dodona-edu/docker-images/dodona-python.dockerfile on purpose, so a
+  # bump to svg-turtle, Pillow, cairosvg or numpy that the image hasn't taken yet gets closed
+  # rather than merged. Those four move when the image moves.
   - package-ecosystem: pip
     directory: "/"
     schedule:
+      interval: monthly
+      time: "04:00"
+      timezone: Europe/Brussels
+    open-pull-requests-limit: 99
+    labels:
+      - dependencies
+    groups:
+      pytest:
+        patterns:
+          - "pytest*"
+      linters:
+        patterns:
+          - "ruff"
+          - "ty"
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
       interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: Europe/Brussels
+    open-pull-requests-limit: 99
+    labels:
+      - dependencies


### PR DESCRIPTION
This PR moves the dependabot updates to monthly, aligned with the other judges.

<details>

The dependabot config here was four lines and did none of what judge-sql's and judge-html's do:

```yaml
version: 2
updates:
  - package-ecosystem: pip
    directory: "/"
    schedule:
      interval: weekly
```

Now matching theirs:

- **`github-actions` covered as well as `pip`**, so the action pins in the workflows stop going stale between manual sweeps. #96 had to bump five of them by hand because nothing was watching.
- **pip monthly instead of weekly**, the call judge-sql made in judge-sql#223, to cut the volume of automated PRs. `github-actions` stays weekly, same split as there.
- **`pytest*` and the linters grouped**, so a bump arrives as one reviewable PR rather than one per package. The linters group names `ruff` and `ty`, which is why this one comes last in the stack: before #98 and #101 it would have been naming tools this repo didn't have.
- **`labels: dependencies`** and `open-pull-requests-limit: 99`, matching the other two.

No comment in the file about the image-mirrored pins. There was one, explaining that `requirements.txt` mirrors `dodona-python.dockerfile` so a bump to svg-turtle, Pillow, cairosvg or numpy ahead of the image gets closed rather than merged, but it was over-explaining for a config file and the reasoning already lives in #95.

</details>

## Testing

Parses, and both entries come out with what's intended:

```
pip            -> monthly | limit: 99 | groups: ['pytest', 'linters']
github-actions -> weekly  | limit: 99 | groups: []
```

Beyond that it can't really be tested before it's on `main`, since dependabot reads the config from the default branch. The visible effect is the next scheduled run.

Last one in the stack. Stacked on #102.

