### PR TITLE
Use the builtins module instead of __builtins__

### DIFF
--- a/judge/runtime.py
+++ b/judge/runtime.py
@@ -1,5 +1,6 @@
 """Turtle runtime."""
 
+import builtins
 import io
 from io import BytesIO
 from pathlib import Path
@@ -20,9 +21,8 @@ def run_file(file_path: str | Path, width: int, height: int, stdin_data: str = "
     with io.open_code(str(Path(file_path).resolve())) as code_file:
         code = compile(code_file.read(), script_name, "exec")
 
-    # In an imported module __builtins__ is the builtins dict, not the module, so this is fine
-    # at runtime. mypy only knows the __main__ case, where it is the module.
-    run_code = __builtins__["exec"]  # type: ignore[index]
+    # Grabbed before the patches below null out builtins.exec for the submission.
+    run_code = builtins.exec
 
     with (
         TurtlePatch(width, height) as turtle,

--- a/judge/runtime_patch.py
+++ b/judge/runtime_patch.py
@@ -1,5 +1,6 @@
 """Turtle runtime patches."""
 
+import builtins
 import sys
 from abc import ABC, abstractmethod
 from collections.abc import Generator
@@ -139,22 +140,22 @@ class RuntimePatch(Patch):
         """Patch generator."""
         old_os = sys.modules["os"]
         old_io = sys.modules["io"]
-        old_open = __builtins__["open"]
-        old_eval = __builtins__["eval"]
-        old_exec = __builtins__["exec"]
+        old_open = builtins.open
+        old_eval = builtins.eval
+        old_exec = builtins.exec
         old_argv = sys.argv
         try:
             sys.modules["os"] = None
             sys.modules["io"] = None
-            __builtins__["open"] = None
-            __builtins__["eval"] = None
-            __builtins__["exec"] = None
+            builtins.open = None
+            builtins.eval = None
+            builtins.exec = None
             sys.argv = [self.name]
             yield
         finally:
             sys.modules["os"] = old_os
             sys.modules["io"] = old_io
-            __builtins__["open"] = old_open
-            __builtins__["eval"] = old_eval
-            __builtins__["exec"] = old_exec
+            builtins.open = old_open
+            builtins.eval = old_eval
+            builtins.exec = old_exec
             sys.argv = old_argv


### PR DESCRIPTION
This PR uses the builtins module rather than calling `__builtins__`.

<details>

Copilot raised this on #98 and it's right, but the fix is bigger than the line it pointed at, so it gets its own PR rather than being bolted onto a lint change.

`__builtins__` is a CPython implementation detail: it's the `builtins` module in `__main__`, and that module's `__dict__` everywhere else. The docs say not to rely on it. Both files here relied on the dict form, and it held only because neither is ever run as `__main__`:

```python
run_code = __builtins__["exec"]        # runtime.py
__builtins__["open"] = None            # runtime_patch.py, x9
```

`builtins.open` is the documented spelling and the same object, so the sandbox behaves identically. Copilot only flagged `runtime.py`, but changing just that one would leave two spellings of the same dict in two files that work together, which is worse than leaving it alone. So both move.

Worth knowing what that code is doing, since it looks odd out of context: `RuntimePatch` deliberately sets `open`, `eval`, `exec`, `os` and `io` to `None` to keep submissions from reaching the filesystem, and `runtime.py` grabs `exec` *before* entering the patch so the judge can still run the compiled submission. That ordering is load-bearing and unchanged.

Also drops the `# type: ignore[index]` in `runtime.py`. That stopped doing anything in #101: `ty` reads `# ty: ignore`, not mypy's comment, so it was a directive aimed at a tool that's no longer in the build.

The `ty` override is untouched. I tried narrowing it and it doesn't give: its three rules cover patching live modules and the `next(self.generator)` call, not the `__builtins__` indexing, so nothing falls away. Dropping `invalid-argument-type` just turns the lint red.

</details>

## Testing

`./devel/check.sh` green (ruff check, ruff format, ty). Suite `7 passed` in the production image with the golden untouched, and `tests/e2e_stdout/.../oef1_dir_read.stdout` is the case that exercises a submission trying to read a directory, so the sandbox is covered there.

Checked the sandbox directly too, rather than inferring it from a green suite:

```
inside:  open/eval/exec/os/io all nulled
after:   all five restored to the originals
```

Stacked on #103.
