### PR TITLE
Document how to run the tests in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 * [Recommended `config.json` (example with default settings)](#recommended-configjson-example-with-default-settings)
 * [Optional `evaluation` settings in `config.json`](#optional-evaluation-settings-in-configjson)
 * [Generator script](#generator-script)
+* [Testing](#testing)
 * [Contributors](#contributors)
 
 ## Recommended exercise directory structure
@@ -150,6 +151,24 @@ The svg images for each exercise can be made with a Python script. Place the scr
 
 ```html
 <img src="./media/image_name.svg" alt="image_name" height="50%" width="50%" style="border-style: inset">
+```
+
+## Testing
+
+The following command can be used to run the tests:
+
+```bash
+$ devel/run-tests.sh
+============================= test session starts ==============================
+platform darwin -- Python 3.12.9, pytest-9.1.1, pluggy-1.6.0
+...
+........                                                                 [100%]
+================================ tests coverage ================================
+_______________ coverage: platform darwin, python 3.12.9-final-0 _______________
+
+Coverage HTML written to dir htmlcov
+Coverage XML written to file coverage.xml
+============================== 8 passed in 3.51s ===============================
 ```
 
 ## Contributors


### PR DESCRIPTION
Last round before we start thinking about the dependabot updates. This PR closes some gaps between the tooling compares to the html and sqlite judge:

The only thing missing was the testing session in the README, all else was OK!

<details>


## What / why

judge-turtle's README had no testing or development section at all, while judge-sql's does. Adds a `## Testing` section mirroring judge-sql's, placed just before `## Contributors`, and lists it in the table of contents.

## Testing

<details>
<summary>Local run of <code>devel/run-tests.sh</code> (macOS, Python 3.12.9, after <code>devel/install_deps.sh</code> + <code>devel/install_test_deps.sh</code>)</summary>

```
$ devel/run-tests.sh
============================= test session starts ==============================
platform darwin -- Python 3.12.9, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/tomnaessens/Documents/Projects/Dodona/judge-turtle/.claude/worktrees/readme-testing
configfile: pyproject.toml
plugins: cov-7.1.0, xdist-3.8.0
created: 12/12 workers
12 workers [8 items]

........                                                                 [100%]
================================ tests coverage ================================
_______________ coverage: platform darwin, python 3.12.9-final-0 _______________

Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml
============================== 8 passed in 3.51s ===============================
```

</details>

To verify: run `devel/run-tests.sh` and check the README's example output block renders correctly.

</details>